### PR TITLE
Remove state-bucket variable

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.2.8
+version: 0.2.9

--- a/stable/datacube-dashboard/templates/install-postgis.yaml
+++ b/stable/datacube-dashboard/templates/install-postgis.yaml
@@ -52,9 +52,4 @@ spec:
             secretKeyRef:
               name: {{ .Values.global.clusterSecret }}
               key: postgres-password
-        - name: STATE_BUCKET
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.global.clusterSecret }}
-              key: state-bucket
       restartPolicy: Never


### PR DESCRIPTION
Update Datacube Dashboard  to not require state-bucket variable that is no longer used.