### PR TITLE
Make wms templates optional based on a wms.enabled flag 

### DIFF
--- a/stable/datacube/Chart.yaml
+++ b/stable/datacube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube
-version: 0.13.2
+version: 0.13.3
 keywords:
 - datacube
 - http

--- a/stable/datacube/templates/autoscaling.yaml
+++ b/stable/datacube/templates/autoscaling.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.wms.autoscaling }}
+{{- if .Values.wms.enabled }}
+{{- if .Values.wms.autoscaling }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -20,4 +21,5 @@ spec:
       resource:
         name: cpu
         targetAverageUtilization: {{ .Values.wms.targetCpu }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/stable/datacube/templates/wms-deployment.yaml
+++ b/stable/datacube/templates/wms-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.wms.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 {{- $externalDb := .Values.global.externalDatabase }}
@@ -136,3 +137,4 @@ spec:
 {{- end }}
 {{- end }}
 status: {}
+{{- end }}

--- a/stable/datacube/templates/wms-ingress.yaml
+++ b/stable/datacube/templates/wms-ingress.yaml
@@ -1,7 +1,8 @@
-{{- if .Values.ingress.enabled -}}
-{{- $serviceName := printf "%s%s" .Release.Name "-wms" -}}
-{{- $servicePort := .Values.wms.externalPort -}}
-{{- $domain := .Values.global.domain}}
+{{- if .Values.wms.enabled }}
+{{- if .Values.ingress.enabled }}
+{{- $serviceName := printf "%s%s" .Release.Name "-wms" }}
+{{- $servicePort := .Values.wms.externalPort }}
+{{- $domain := .Values.global.domain }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -34,5 +35,6 @@ spec:
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/datacube/templates/wms-service.yaml
+++ b/stable/datacube/templates/wms-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.wms.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
   selector:
     app: {{ template "datacube.name" . }}
     release: {{ .Release.Name }}
+{{- end }}


### PR DESCRIPTION
with this change datacube databases can be created using this helm chart without a wms.