### PR TITLE
Add Dummy Config map when WMS is not enabled

### DIFF
--- a/stable/datacube/Chart.yaml
+++ b/stable/datacube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube
-version: 0.15.0
+version: 0.16.0
 keywords:
 - datacube
 - http

--- a/stable/datacube/templates/dummy-cm.yaml
+++ b/stable/datacube/templates/dummy-cm.yaml
@@ -1,0 +1,8 @@
+{{- if not .Values.wms.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "datacube-dask.fullname" . }}-dummy
+data:
+  dummydata: donotuse
+{{- end }}


### PR DESCRIPTION
stops Helm emitting an error message which can interfere with CI / CD tools