### PR TITLE
Allow secretKeyRefs name overrides in datacube-dashboard

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.4.0
+version: 0.4.1

--- a/stable/datacube-dashboard/templates/deployment.yaml
+++ b/stable/datacube-dashboard/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $externalDb := .Values.global.externalDatabase }}
 {{- $dc := .Values.global.datacube }}
+{{- $secretName := empty .Values.secretName | ternary .Values.global.externalDatabase.database .Values.secretName }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -32,12 +33,12 @@ spec:
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ $externalDb.database }}
+              name: {{ $secretName }}
               key: postgres-username
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $externalDb.database }}
+              name: {{ $secretName }}
               key: postgres-password
         - name: VIRTUAL_HOST
           value: localhost,127.0.0.

--- a/stable/datacube-dashboard/templates/install-postgis.yaml
+++ b/stable/datacube-dashboard/templates/install-postgis.yaml
@@ -1,6 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 {{ $externalDb := .Values.global.externalDatabase }}
+{{- $secretName := empty .Values.secretName | ternary .Values.global.externalDatabase.database .Values.secretName }}
+{{- $adminSecretName := empty .Values.adminSecretName | ternary .Values.global.externalDatabase.database .Values.adminSecretName }}
 metadata:
   name: "{{ include "datacube-dashboard.fullname" . }}-postgis-install"
   labels:
@@ -35,21 +37,21 @@ spec:
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ $externalDb.database }}
+              name: {{ $secretName }}
               key: postgres-username
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $externalDb.database }}
+              name: {{ $secretName }}
               key: postgres-password
         - name: ADMIN_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.clusterSecret }}
+              name: {{ $adminSecretName }}
               key: postgres-username
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.clusterSecret }}
+              name: {{ $adminSecretName }}
               key: postgres-password
       restartPolicy: Never

--- a/stable/datacube-dashboard/templates/update_db.yaml
+++ b/stable/datacube-dashboard/templates/update_db.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.update.enabled }}
 {{- $externalDb := .Values.global.externalDatabase }}
 {{- $dc := .Values.global.datacube }}
+{{- $secretName := empty .Values.secretName | ternary .Values.global.externalDatabase.database .Values.secretName }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -43,12 +44,12 @@ spec:
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ $externalDb.database }}
+                  name: {{ $secretName }}
                   key: postgres-username
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $externalDb.database }}
+                  name: {{ $secretName }}
                   key: postgres-password
             {{- if .Values.additionalEnvironmentVars }}
             {{- range $arg, $value := .Values.update.additionalEnvironmentVars }}

--- a/stable/datacube-dashboard/values.yaml
+++ b/stable/datacube-dashboard/values.yaml
@@ -8,10 +8,11 @@ image:
   tag: 'stable'
   pullPolicy: Always
 
-
 global:
   datacube:
     configPath: /opt/odc/datacube.conf
+  externalDatabase:
+    database:
 
 resources:
   limits:


### PR DESCRIPTION
Allow secretName and adminSecretName to be set as values to use as the name for secretKeyRefs for DB and ADMIN DB usernames and passwords