### PR TITLE
postgis install to run as a job instead of hook

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.4.5
+version: 0.4.6

--- a/stable/datacube-dashboard/templates/install-postgis.yaml
+++ b/stable/datacube-dashboard/templates/install-postgis.yaml
@@ -9,10 +9,6 @@ metadata:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-4"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:


### PR DESCRIPTION
Prevents helm / tiller entering a state which is unrecoverable automatically by flux.