### PR TITLE
fix ingress annotation indentation

### DIFF
--- a/stable/datacube/Chart.yaml
+++ b/stable/datacube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube
-version: 0.16.1
+version: 0.16.2
 keywords:
 - datacube
 - http

--- a/stable/datacube/templates/wms-ingress.yaml
+++ b/stable/datacube/templates/wms-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 6 }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
 spec:
   rules:
 {{- range $hostPrefix := .Values.ingress.hostPrefix }}


### PR DESCRIPTION
before this change:

```
ingress:
    annotations:
        kubernetes.io/ingress.class: alb
        alb.ingress.kubernetes.io/scheme: internet-facing
```

-> 
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
   annotations:
        kubernetes.io/ingress.class: alb
        alb.ingress.kubernetes.io/scheme: internet-facing
```

because the indentation is wrong it get's ignored by kubernetes

after this change

-> 
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
   annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/scheme: internet-facing
```