### PR TITLE
Index chart updates

### DIFF
--- a/stable/datacube-index/Chart.yaml
+++ b/stable/datacube-index/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube OGC Web Services Indexing
 name: datacube-index
-version: 0.3.14
+version: 0.4.0
 keywords:
 - datacube
 - http

--- a/stable/datacube-index/templates/archive.yaml
+++ b/stable/datacube-index/templates/archive.yaml
@@ -1,11 +1,11 @@
-{{- $externalDb := .Values.global.externalDatabase }}
-{{- $dc := .Values.global.datacube }}
+{{- if .Values.archive.enable }}
+{{- $dc := .Values.datacube }}
 {{- $archive := .Values.archive }}
-{{- $image := .Values.global.image }}
+{{- $image := .Values.image }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: "{{ $externalDb.database }}-archive"
+  name: {{template "datacube-index.fullname" .}}-archive
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
@@ -20,7 +20,7 @@ spec:
     spec:
       template:
         metadata:
-          name: "{{ $externalDb.database }}-archive"
+          name: {{template "datacube-index.fullname" .}}-archive
           labels:
             heritage: {{.Release.Service | quote }}
             release: {{.Release.Name | quote }}
@@ -33,7 +33,7 @@ spec:
           initContainers:
           - name: postgres-listener
             image: alpine
-            command: ["sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ $externalDb.host }} {{ $externalDb.port }} && exit 0 || sleep 3; done; exit 1"]
+            command: ["sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Values.database.host }} {{ .Values.database.port }} && exit 0 || sleep 3; done; exit 1"]
           containers:
           - name: datacube-archive
             image: "{{ $image.repository }}:{{ $image.tag }}"
@@ -53,20 +53,20 @@ spec:
             - name: DC_ARCHIVE_DAYS
               value: {{ $archive.days | quote }}
             - name: DB_HOSTNAME
-              value: {{ $externalDb.host | quote }}
+              value: {{ .Values.database.host | quote }}
             - name: DB_PORT
-              value: {{ $externalDb.port | quote }}
+              value: {{ .Values.database.port | quote }}
             - name: DB_DATABASE
-              value: {{ $externalDb.database | quote }}
+              value: {{ .Values.database.database | quote }}
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ $externalDb.database }}
+                  name: {{ .Values.database.existingSecret }}
                   key: postgres-username
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $externalDb.database }}
+                  name: {{ .Values.database.existingSecret }}
                   key: postgres-password
             {{- if $archive.additionalEnvironmentVars }}
             {{- range $arg, $value := $archive.additionalEnvironmentVars }}
@@ -88,3 +88,4 @@ spec:
               {{ if .memory }}memory: {{ .memory | quote }} {{ end }}
             {{- end }}
           {{- end }}
+{{- end }}

--- a/stable/datacube-index/templates/cronjob-index.yaml
+++ b/stable/datacube-index/templates/cronjob-index.yaml
@@ -1,8 +1,7 @@
 {{- if .Values.cron.enabled }}
-{{- $externalDb := .Values.global.externalDatabase }}
-{{- $dc := .Values.global.datacube }}
+{{- $dc := .Values.datacube }}
 {{- $index := .Values.index }}
-{{- $image := .Values.global.image }}
+{{- $image := .Values.image }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -35,7 +34,7 @@ spec:
           initContainers:
           - name: postgres-listener
             image: alpine
-            command: ["sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ $externalDb.host }} {{ $externalDb.port }} && exit 0 || sleep 3; done; exit 1"]
+            command: ["sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Values.database.host }} {{ .Values.database.port }} && exit 0 || sleep 3; done; exit 1"]
           containers:
           - name: datacube-index
             image: "{{ $image.repository }}:{{ $image.tag }}"
@@ -79,20 +78,20 @@ spec:
                 value: {{ $index.ignore_lineage | quote }}
             {{- end }}
               - name: DB_HOSTNAME
-                value: {{ $externalDb.host | quote }}
+                value: {{ .Values.database.host | quote }}
               - name: DB_PORT
-                value: {{ $externalDb.port | quote }}
+                value: {{ .Values.database.port | quote }}
               - name: DB_DATABASE
-                value: {{ $externalDb.database | quote }}
+                value: {{ .Values.database.database | quote }}
               - name: DB_USERNAME
                 valueFrom:
                   secretKeyRef:
-                    name: {{ $externalDb.database }}
+                    name: {{ .Values.database.existingSecret }}
                     key: postgres-username
               - name: DB_PASSWORD
                 valueFrom:
                   secretKeyRef:
-                    name: {{ $externalDb.database }}
+                    name: {{ .Values.database.existingSecret }}
                     key: postgres-password
           {{- if $index.additionalEnvironmentVars }}
           {{- range $arg, $value := $index.additionalEnvironmentVars }}

--- a/stable/datacube-index/templates/index.yaml
+++ b/stable/datacube-index/templates/index.yaml
@@ -1,32 +1,30 @@
-{{- $externalDb := .Values.global.externalDatabase }}
-{{- $dc := .Values.global.datacube }}
+{{- $dc := .Values.datacube }}
 {{- $index := .Values.index }}
-{{- $image := .Values.global.image }}
+{{- $image := .Values.image }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ $index.jobname }}"
+  name: {{template "datacube-index.fullname" .}}
   labels:
-    heritage: {{ $index.jobname }}
-    release: {{ $index.jobname }}
-    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
-    component: index
+    app.kubernetes.io/name: {{ include "datacube-index.name" . }}
+    helm.sh/chart: {{ include "datacube-index.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   backoffLimit: 1
   template:
     metadata:
-      name: "{{ $index.jobname }}"
+      name: {{ include "datacube-index.fullname" . }}
       labels:
-        heritage: {{ $index.jobname }}
-        release: {{ $index.jobname }}
-        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        heritage: {{ include "datacube-index.fullname" . }}
+        release: {{ .Release.Name }}
       annotations:
 {{ toYaml $index.annotations | indent 8 }}
     spec:
       initContainers:
       - name: postgres-listener
         image: alpine
-        command: ["sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ $externalDb.host }} {{ $externalDb.port }} && exit 0 || sleep 3; done; exit 1"]
+        command: ["sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Values.database.host }} {{ .Values.database.port }} && exit 0 || sleep 3; done; exit 1"]
       containers:
       - name: datacube-index
         image: "{{ $image.repository }}:{{ $image.tag }}"
@@ -79,20 +77,20 @@ spec:
           value: {{ $index.ignore_lineage | quote }}
 {{- end }}
         - name: DB_HOSTNAME
-          value: {{ $externalDb.host | quote }}
+          value: {{ .Values.database.host | quote }}
         - name: DB_PORT
-          value: {{ $externalDb.port | quote }}
+          value: {{ .Values.database.port | quote }}
         - name: DB_DATABASE
-          value: {{ $externalDb.database | quote }}
+          value: {{ .Values.database.database | quote }}
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ $externalDb.database }}
+              name: {{ .Values.database.existingSecret }}
               key: postgres-username
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $externalDb.database }}
+              name: {{ .Values.database.existingSecret }}
               key: postgres-password
 {{- if $index.additionalEnvironmentVars }}
 {{- range $arg, $value := $index.additionalEnvironmentVars }}

--- a/stable/datacube-index/values.yaml
+++ b/stable/datacube-index/values.yaml
@@ -29,6 +29,7 @@ index:
   thredds_days:
 
 archive:
+  enable: false
   dockerArgs: [ "/bin/bash", "-c", "cd archive; ./archive-wrapper.sh" ]
   imageTag: archive-k
   historyLimit: 5
@@ -57,8 +58,20 @@ cron:
   concurrencyPolicy: Allow
   historyLimit: 1
   
-global:
-  datacube:
-    configPath: /opt/odc/datacube.conf
-    wmsConfigURL: 
-    products: 
+image:
+  registry: docker.io
+  repository: opendatacube/ows
+  tag: 'latest'
+  pullPolicy: Always
+
+
+datacube:
+  configPath: /opt/odc/datacube.conf
+  wmsConfigURL: "" 
+  products: []
+
+database:
+  database: datacube
+  host: localhost
+  port: 5432
+  existingSecret: datacube


### PR DESCRIPTION
Update index chart to not use global.externalDatabase
index chart does not use index.jobname to name create jobs
archive cronjob is now disabled by default and will not be created
Add instructions to README.md for indexing multiple x_ folders in dea-public-data using parallel helm jobs