### PR TITLE
update worker args to explicitly include `dask-worker`

### DIFF
--- a/stable/datacube-dask/Chart.yaml
+++ b/stable/datacube-dask/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "alpha"
 description: Distributed Dask for Datacube
 name: datacube-dask
-version: 0.4.0
+version: 0.4.1

--- a/stable/datacube-dask/templates/worker-deployment.yaml
+++ b/stable/datacube-dask/templates/worker-deployment.yaml
@@ -29,10 +29,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ {{- range .Values.worker.command }} {{ . | quote }}, {{ end -}}  ]
           args:
-          {{- if not .Values.worker.schedulerAddress }}
-          - {{ include "datacube-dask.fullname" . }}:{{ .Values.scheduler.port }}
-          {{- else }}
+          - dask-worker
+          {{- if .Values.worker.schedulerAddress }}
           - {{ .Values.worker.schedulerAddress }}
+          {{- else }}
+          - {{ include "datacube-dask.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.scheduler.port }}
           {{- end }}
           {{- range .Values.worker.args }}
           - {{ . | quote }}

--- a/stable/datacube-dask/templates/worker-deployment.yaml
+++ b/stable/datacube-dask/templates/worker-deployment.yaml
@@ -27,7 +27,12 @@ spec:
         - name: {{ template "datacube-dask.name" . }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ {{- range .Values.worker.command }} {{ . | quote }}, {{ end -}}  ]
+          command:
+          {{- if .Values.worker.command }}
+           {{- range .Values.worker.command }} {{ . | quote }}, {{ end -}}
+          {{- else }}
+          - docker-entrypoint.sh
+          {{- end}}
           args:
           - dask-worker
           {{- if .Values.worker.schedulerAddress }}

--- a/stable/datacube-dask/templates/worker-deployment.yaml
+++ b/stable/datacube-dask/templates/worker-deployment.yaml
@@ -29,7 +29,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           {{- if .Values.worker.command }}
-           {{- range .Values.worker.command }} {{ . | quote }}, {{ end -}}
+          {{- range .Values.worker.command }}
+          - {{ . | quote }}
+          {{- end }}
           {{- else }}
           - docker-entrypoint.sh
           {{- end}}


### PR DESCRIPTION
I think this is the best way to do it. I can't imagine one wanting the dask worker to not run the dask worker command.

Another enhancement would be to use the entrypoint as the default `command`.