### PR TITLE
selector for worker matched both worker and scheduler causing issues with hpa

### DIFF
--- a/stable/datacube-dask/Chart.yaml
+++ b/stable/datacube-dask/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "alpha"
 description: Distributed Dask for Datacube
 name: datacube-dask
-version: 0.4.1
+version: 0.4.2

--- a/stable/datacube-dask/templates/worker-deployment.yaml
+++ b/stable/datacube-dask/templates/worker-deployment.yaml
@@ -13,12 +13,12 @@ spec:
   replicas: {{ .Values.worker.minReplicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "datacube-dask.name" . }}
+      app.kubernetes.io/name: {{ include "datacube-dask.name" . }}-worker
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "datacube-dask.name" . }}
+        app.kubernetes.io/name: {{ include "datacube-dask.name" . }}-worker
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
 {{ toYaml .Values.worker.annotations | indent 8 }}


### PR DESCRIPTION
This change ensures both can be seperated, and should allow hpa to determine current worker cpu stats