### PR TITLE
Automate explorer indexing

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.5.3
+version: 0.5.4

--- a/stable/datacube-dashboard/templates/update_creation_dt.yaml
+++ b/stable/datacube-dashboard/templates/update_creation_dt.yaml
@@ -1,19 +1,19 @@
-{{- if .Values.update.enabled }}
+{{- if .Values.update_creation_dt.enabled }}
 {{- $dc := .Values.datacube }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: '{{ include "datacube-dashboard.fullname" . }}-update-index'
+  name: '{{ include "datacube-dashboard.fullname" . }}-update-dt'
   labels:
     app.kubernetes.io/name: {{ include "datacube-dashboard.name" . }}
     helm.sh/chart: {{ include "datacube-dashboard.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.update.cron | quote }}
-  successfulJobsHistoryLimit: {{ .Values.update.historyLimit}}
-  failedJobsHistoryLimit: {{ .Values.update.historyLimit }}
-  suspend: {{ .Values.update.suspend }}
+  schedule: {{ .Values.update_creation_dt.cron | quote }}
+  successfulJobsHistoryLimit: {{ .Values.update_creation_dt.historyLimit}}
+  failedJobsHistoryLimit: {{ .Values.update_creation_dt.historyLimit }}
+  suspend: {{ .Values.update_creation_dt.suspend }}
   jobTemplate:
     spec:
       template:
@@ -28,10 +28,10 @@ spec:
           {{- end }}
         spec:
           containers:
-          - name: cubedash-updater
+          - name: cubedash-update-creation-dt
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
-            args: [ {{- range .Values.update.dockerArgs }} {{ . | quote }}, {{ end -}} ]
+            args: [ {{- range .Values.update_creation_dt.dockerArgs }} {{ . | quote }}, {{ end -}} ]
             env:
             - name: DB_HOSTNAME
               value: {{ .Values.database.host | quote }}
@@ -50,7 +50,7 @@ spec:
                   name: {{ .Values.database.existingSecret }}
                   key: postgres-password
             {{- if .Values.additionalEnvironmentVars }}
-            {{- range $arg, $value := .Values.update.additionalEnvironmentVars }}
+            {{- range $arg, $value := .Values.update_creation_dt.additionalEnvironmentVars }}
             - name: {{ $arg | quote }}
               value: {{ $value | quote }}
             {{- end }}

--- a/stable/datacube-dashboard/values.yaml
+++ b/stable/datacube-dashboard/values.yaml
@@ -95,26 +95,3 @@ ingress:
     - ""
   annotations:
     kubernetes.io/ingress.class: alb
-
-## Define readiness probe
-## For a readiness probe, giving up means not routing traffic to the pod, but the pod is not restarted.
-readinessProbe:
-  httpGet:
-    path: "/aster_false_colour"
-    port: 8080
-  initialDelaySeconds: 60
-  periodSeconds: 60 # how long to wait between checks
-  successThreshold: 1 # how many successes to hit before accepting
-  failureThreshold: 3 # how many failures to accept before failing
-  timeoutSeconds: 20 # how long to wait for a response
-## Define a TCP liveness probe
-## For a liveness probe, giving up means the pod will be restarted.
-livenessProbe:
-  httpGet:
-    path: "/aster_false_colour"
-    port: 8080
-  initialDelaySeconds: 60
-  periodSeconds: 60 # how long to wait between checks
-  successThreshold: 1 # how many successes to hit before accepting
-  failureThreshold: 3 # how many failures to accept before failing
-  timeoutSeconds: 20 # how long to wait for a response

--- a/stable/datacube-dashboard/values.yaml
+++ b/stable/datacube-dashboard/values.yaml
@@ -89,23 +89,12 @@ additionalSettings: |
   STAC_PAGE_SIZE_LIMIT = 1000
 
 ingress:
-  enabled: true
+  enabled: false
   path: "/*"
   hosts:
-    - "explorer.dev.dea.ga.gov.au"
+    - ""
   annotations:
     kubernetes.io/ingress.class: alb
-
-    # set ALB parameters
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/healthcheck-path: "/aster_false_colour"
-    alb.ingress.kubernetes.io/success-codes: "200"
-    alb.ingress.kubernetes.io/connection-idle-timeout: "180"
-    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "30"
-    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "15"
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-southeast-2:451924316694:certificate/3ad4ae2d-7ccd-4f8a-aa6b-f59544e0d61f
 
 ## Define readiness probe
 ## For a readiness probe, giving up means not routing traffic to the pod, but the pod is not restarted.

--- a/stable/datacube-dashboard/values.yaml
+++ b/stable/datacube-dashboard/values.yaml
@@ -11,30 +11,16 @@ image:
 datacube:
   configPath: /opt/odc/datacube.conf
 database:
-  database: postgres
+  database: ows
   host: db-dev-eks-datacube-default.cxhoeczwhtar.ap-southeast-2.rds.amazonaws.com
   port: 5432
   adminSecret: dev-eks-datacube
-  existingSecret: dev-eks-datacube
+  existingSecret: ows
 
-resources:
-  limits:
-    cpu: "300m"
-    memory: 1024Mi
-dockerArgs: [ "gunicorn", "-b", "0.0.0.0:8080", "-w", "4", "--timeout", "60", "cubedash:app" ]
-annotations:
-  iam.amazonaws.com/role: dev-eks-datacube-wms
-additionalEnvironmentVars: { }
-update:
-  enabled: false
-  historyLimit: 1
-  cron: "15 14 * * *"  ## Run every midnight at 00:15:00 am AEST
-  suspend: false
-  dockerArgs: [ "cubedash-gen", "--all", "||", "true"]
-
-service:
-  type: NodePort
-  port: 80
+global:
+  externalDatabase:
+    database: ows
+  clusterSecret: ows
 
 setup:
   dockerArgs: [ "/bin/bash", "-c", "PGPASSWORD=$ADMIN_PASSWORD psql -h $DB_HOSTNAME -p 5432 -U $ADMIN_USERNAME -d $DB_DATABASE -c 'CREATE EXTENSION IF NOT EXISTS postgis'" ]
@@ -44,33 +30,102 @@ setup:
     tag: latest
     pullPolicy: IfNotPresent
 
+resources:
+  limits:
+    cpu: "300m"
+    memory: 1024Mi
+
+annotations:
+  iam.amazonaws.com/role: dev-eks-datacube-wms
+
+additionalEnvironmentVars: { }
+
+service:
+  type: NodePort
+  port: 80
 containerPort: 8080 # Internal port on which pod is running and serving cubedash app
 
-ingress:
-  ## Enable Ingress.
-  ##
+update:
   enabled: false
-  host:
+  historyLimit: 1
+  cron: "0 */6 * * *"  ## Run every 6 hours
+  suspend: false
+  dockerArgs: [ "cubedash-gen", "--all", "||", "true"]
+dockerArgs: [ "gunicorn", "-b", "0.0.0.0:8080", "-w", "4", "--timeout", "60", "cubedash:app" ]
 
-## Define a TCP liveness probe
-## For a liveness probe, giving up means the pod will be restarted.
-livenessProbe:
-  httpGet:
-    path: "/"
-    port: 8080
-  initialDelaySeconds: 10
-  periodSeconds: 10
+update_creation_dt:
+  enabled: false
+  historyLimit: 1
+  cron: "0 13 * * *"  ## Run daily at 11 pm AEST
+  suspend: false
+  # dataset_type_ref id for the desired product is obtained from `SELECT id,name FROM agdc.dataset_type;` psql command
+  dockerArgs:
+    - [ "psql", "-c", "'drop schema if exists cubedash cascade'"]
+    - [ "psql", "-c", "'UPDATE agdc.dataset d SET metadata = jsonb_build_object('creation_dt', s.metadata#>>'{extent, center_dt}') || s.metadata FROM agdc.dataset s WHERE d.dataset_type_ref=81 AND d.id = s.id'"]
+    - [ "psql", "-c", "'UPDATE agdc.dataset d SET metadata = jsonb_build_object('creation_dt', s.metadata#>>'{extent, center_dt}') || s.metadata FROM agdc.dataset s WHERE d.dataset_type_ref=82 AND d.id = s.id'"]
+    - [ "psql", "-c", "'UPDATE agdc.dataset d SET metadata = jsonb_build_object('creation_dt', s.metadata#>>'{extent, center_dt}') || s.metadata FROM agdc.dataset s WHERE d.dataset_type_ref=83 AND d.id = s.id'"]
+    - [ "psql", "-c", "'UPDATE agdc.dataset d SET metadata = jsonb_build_object('creation_dt', s.metadata#>>'{extent, center_dt}') || s.metadata FROM agdc.dataset s WHERE d.dataset_type_ref=84 AND d.id = s.id'"]
+
+additionalSettings: |
+  CUBEDASH_THEME='dea'
+  CUBEDASH_DEFAULT_PRODUCTS = ('aster_false_colour','ls5_fc_albers','ls7_fc_albers',)
+
+  # Which field should we use when grouping products in the top menu?
+  CUBEDASH_PRODUCT_GROUP_BY_FIELD = 'product_type'
+
+  # Ungrouped products will be grouped together in this size.
+  CUBEDASH_PRODUCT_GROUP_SIZE = 5
+
+  # Maximum search results
+  CUBEDASH_HARD_SEARCH_LIMIT = 100
+
+  # Maximum number of source/derived datasets to show
+  CUBEDASH_PROVENANCE_DISPLAY_LIMIT = 30
+
+  # Customise '/stac' endpoint information
+  STAC_ENDPOINT_ID = 'AWS_Dev_EKS_Explorer'
+  STAC_ENDPOINT_TITLE = 'AWS dev eks explorer'
+  STAC_DEFAULT_PAGE_SIZE = 20
+  STAC_PAGE_SIZE_LIMIT = 1000
+
+ingress:
+  enabled: true
+  path: "/*"
+  hosts:
+    - "explorer.dev.dea.ga.gov.au"
+  annotations:
+    kubernetes.io/ingress.class: alb
+
+    # set ALB parameters
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/healthcheck-path: "/aster_false_colour"
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/connection-idle-timeout: "180"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "30"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "15"
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-southeast-2:451924316694:certificate/3ad4ae2d-7ccd-4f8a-aa6b-f59544e0d61f
 
 ## Define readiness probe
 ## For a readiness probe, giving up means not routing traffic to the pod, but the pod is not restarted.
 readinessProbe:
   httpGet:
-    path: "/"
+    path: "/aster_false_colour"
     port: 8080
-  initialDelaySeconds: 5
-  periodSeconds: 10
-
-additionalSettings: |
-  CUBEDASH_THEME='dea'
-  CUBEDASH_DEFAULT_PRODUCTS = ('ls5_fc_albers',)
-  CUBEDASH_PROVENANCE_DISPLAY_LIMIT = 30
+  initialDelaySeconds: 60
+  periodSeconds: 60 # how long to wait between checks
+  successThreshold: 1 # how many successes to hit before accepting
+  failureThreshold: 3 # how many failures to accept before failing
+  timeoutSeconds: 20 # how long to wait for a response
+## Define a TCP liveness probe
+## For a liveness probe, giving up means the pod will be restarted.
+livenessProbe:
+  httpGet:
+    path: "/aster_false_colour"
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 60 # how long to wait between checks
+  successThreshold: 1 # how many successes to hit before accepting
+  failureThreshold: 3 # how many failures to accept before failing
+  timeoutSeconds: 20 # how long to wait for a response


### PR DESCRIPTION
**Background:**
`Cubedash` `Summary` `Generation` throws an exception if datasets `Creation time` (by default: `'creation_dt'` in the `yaml`) is `Null`. Because of this error, `product`/`datasets` would not be updated or added to the explorer dashboard.

**Fix for the issue described above:**
- Add `datacube dashboard` `template` to automate `explorer` `summary` `generation` that would setup a `cron` `job` to  update the `creation dt`