### PR TITLE
Turn on single-request-reopen option to fix intermittent delays

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.5.5
+version: 0.5.6

--- a/stable/datacube-dashboard/templates/deployment.yaml
+++ b/stable/datacube-dashboard/templates/deployment.yaml
@@ -27,6 +27,11 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       terminationGracePeriodSeconds: 30
       containers:
         - name: {{ .Chart.Name }}

--- a/stable/datacube-dashboard/templates/install-postgis.yaml
+++ b/stable/datacube-dashboard/templates/install-postgis.yaml
@@ -19,6 +19,11 @@ spec:
         release: {{.Release.Name | quote }}
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       terminationGracePeriodSeconds: 30
       containers:
       - name: install-postgis-extension

--- a/stable/datacube-dashboard/templates/install-postgis.yaml
+++ b/stable/datacube-dashboard/templates/install-postgis.yaml
@@ -19,11 +19,6 @@ spec:
         release: {{.Release.Name | quote }}
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
-      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
-      # not handled correctly it will close the socket and open a new one before sending the second request.
-      dnsConfig:
-        options:
-          - name: single-request-reopen
       terminationGracePeriodSeconds: 30
       containers:
       - name: install-postgis-extension

--- a/stable/datacube-dask/Chart.yaml
+++ b/stable/datacube-dask/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "alpha"
 description: Distributed Dask for Datacube
 name: datacube-dask
-version: 0.4.3
+version: 0.4.4

--- a/stable/datacube-dask/templates/deployment.yaml
+++ b/stable/datacube-dask/templates/deployment.yaml
@@ -19,6 +19,11 @@ spec:
         app.kubernetes.io/name: {{ include "datacube-dask.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       {{- if .Values.adaptive.enabled }}
       serviceAccountName: {{ include "datacube-dask.fullname" . }}
       {{- end }}

--- a/stable/datacube-dask/templates/worker-deployment.yaml
+++ b/stable/datacube-dask/templates/worker-deployment.yaml
@@ -23,6 +23,11 @@ spec:
       annotations:
 {{ toYaml .Values.worker.annotations | indent 8 }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       containers:
         - name: {{ template "datacube-dask.name" . }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datacube-data/Chart.yaml
+++ b/stable/datacube-data/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for running datacube data management
 name: datacube-data
-version: 0.2.0
+version: 0.2.1

--- a/stable/datacube-data/templates/deployment.yaml
+++ b/stable/datacube-data/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datacube-index/Chart.yaml
+++ b/stable/datacube-index/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube OGC Web Services Indexing
 name: datacube-index
-version: 0.4.0
+version: 0.4.1
 keywords:
 - datacube
 - http

--- a/stable/datacube-index/templates/archive.yaml
+++ b/stable/datacube-index/templates/archive.yaml
@@ -30,6 +30,11 @@ spec:
             {{ $key }}: {{ $value | quote }}
           {{- end }}
         spec:
+          # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+          # not handled correctly it will close the socket and open a new one before sending the second request.
+          dnsConfig:
+            options:
+              - name: single-request-reopen
           initContainers:
           - name: postgres-listener
             image: alpine

--- a/stable/datacube-index/templates/cronjob-index.yaml
+++ b/stable/datacube-index/templates/cronjob-index.yaml
@@ -30,6 +30,11 @@ spec:
           annotations:
 {{ toYaml $index.annotations | indent 12 }}
         spec:
+          # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+          # not handled correctly it will close the socket and open a new one before sending the second request.
+          dnsConfig:
+            options:
+              - name: single-request-reopen
           restartPolicy: Never
           initContainers:
           - name: postgres-listener

--- a/stable/datacube-index/templates/index.yaml
+++ b/stable/datacube-index/templates/index.yaml
@@ -21,6 +21,11 @@ spec:
       annotations:
 {{ toYaml $index.annotations | indent 8 }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       initContainers:
       - name: postgres-listener
         image: alpine

--- a/stable/datacube-processing/Chart.yaml
+++ b/stable/datacube-processing/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for datacube processing
 name: datacube-processing
-version: 0.1.0
+version: 0.1.1

--- a/stable/datacube-processing/templates/processing-job.yaml
+++ b/stable/datacube-processing/templates/processing-job.yaml
@@ -34,6 +34,11 @@ spec:
             {{ $key }}: {{ $value | quote }}
           {{- end }}
         spec:
+          # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+          # not handled correctly it will close the socket and open a new one before sending the second request.
+          dnsConfig:
+            options:
+              - name: single-request-reopen
           restartPolicy: Never
           initContainers:
             - name: postgres-listener

--- a/stable/datacube-wps/Chart.yaml
+++ b/stable/datacube-wps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: alpha
 description: A Helm chart for Datacube WPS on Kubernetes
 name: datacube-wps
-version: 0.7.2
+version: 0.7.3

--- a/stable/datacube-wps/templates/deployment.yaml
+++ b/stable/datacube-wps/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       initContainers:
       {{- if .Values.wpsConfig.image }}
       - name: wps-config

--- a/stable/datacube/Chart.yaml
+++ b/stable/datacube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube
-version: 0.17.5
+version: 0.17.7
 keywords:
 - datacube
 - http

--- a/stable/datacube/templates/create-database-job.yaml
+++ b/stable/datacube/templates/create-database-job.yaml
@@ -21,6 +21,9 @@ spec:
         release: {{.Release.Name | quote }}
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       containers:
       - name: create-db
         image: "{{ $image.repository }}:{{ $image.tag }}"

--- a/stable/datacube/templates/datacube-init-hook.yaml
+++ b/stable/datacube/templates/datacube-init-hook.yaml
@@ -19,6 +19,9 @@ spec:
         release: {{.Release.Name | quote }}
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       initContainers:
       - name: wait-for
         image: alpine:latest

--- a/stable/datacube/templates/wms-deployment.yaml
+++ b/stable/datacube/templates/wms-deployment.yaml
@@ -13,19 +13,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  securityContext:
-    sysctls:
-      # If this flag is set to 1 then all System V shared memory segments will be marked for destruction as soon as
-      # the number of attached processes falls to zero
-      - name: kernel.shm_rmid_forced
-        value: "0"
-      # comment out ipv6 localhost
-      - name: net.ipv6.conf.all.disable_ipv6
-        value: "1"
-      - name: net.ipv6.conf.default.disable_ipv6
-        value: "1"
-      - name: net.ipv6.conf.lo.disable_ipv6
-        value: "1"
 {{- if not .Values.wms.autoscaling }}
   replicas: {{ .Values.minReplicas }}
 {{- end }}
@@ -77,12 +64,12 @@ spec:
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.database.existingSecret }}
+              name: {{ template "datacube.secretName" . }}
               key: postgres-username
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.database.existingSecret }}
+              name: {{ template "datacube.secretName" . }}
               key: postgres-password
         - name: VIRTUAL_HOST
           value: localhost,127.0.0.

--- a/stable/datacube/templates/wms-deployment.yaml
+++ b/stable/datacube/templates/wms-deployment.yaml
@@ -13,6 +13,19 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  securityContext:
+    sysctls:
+      # If this flag is set to 1 then all System V shared memory segments will be marked for destruction as soon as
+      # the number of attached processes falls to zero
+      - name: kernel.shm_rmid_forced
+        value: "0"
+      # comment out ipv6 localhost
+      - name: net.ipv6.conf.all.disable_ipv6
+        value: "1"
+      - name: net.ipv6.conf.default.disable_ipv6
+        value: "1"
+      - name: net.ipv6.conf.lo.disable_ipv6
+        value: "1"
 {{- if not .Values.wms.autoscaling }}
   replicas: {{ .Values.minReplicas }}
 {{- end }}
@@ -29,6 +42,11 @@ spec:
       annotations:
 {{ toYaml .Values.wms.annotations | indent 8 }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+        - name: single-request-reopen
       initContainers:
 {{- if .Values.wmsConfig.image }}
       - name: wms-config
@@ -59,12 +77,12 @@ spec:
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ template "datacube.secretName" . }}
+              name: {{ .Values.database.existingSecret }}
               key: postgres-username
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "datacube.secretName" . }}
+              name: {{ .Values.database.existingSecret }}
               key: postgres-password
         - name: VIRTUAL_HOST
           value: localhost,127.0.0.

--- a/stable/restcube/Chart.yaml
+++ b/stable/restcube/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.1
 description: A Helm chart for Deploying RestCube
 name: restcube
-version: 0.2.0
+version: 0.2.1

--- a/stable/restcube/templates/celery-worker-deployment.yaml
+++ b/stable/restcube/templates/celery-worker-deployment.yaml
@@ -23,6 +23,11 @@ spec:
 {{ toYaml . | indent 8}}
       {{- end }}
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/restcube/templates/deployment.yaml
+++ b/stable/restcube/templates/deployment.yaml
@@ -23,6 +23,11 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}    
     spec:
+      # Turning single-request-reopen option on would fix issue where in two requests from the same port are
+      # not handled correctly it will close the socket and open a new one before sending the second request.
+      dnsConfig:
+        options:
+          - name: single-request-reopen
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
# Reason for this PR
DNS resolver sends out two DNS requests, one for the `A (ipv4)` record and one for the `AAAA (ipv6)` record, on the same port. This is the default since `glbc 2.9` to do them in parallel. Intermittently, `A` record is returned almost immediately whereas `AAAA` record timeouts after some while, causing the library to think that overall lookup has timed out. This causes `libc` to retry after waiting for 5 seconds. Thus causing `dns` resolution to be delayed by multiple of 5 seconds.

# Resolution
Turn on `single-request-reopen` (since glibc 2.9) `dnsConfig` option fixes issue with the `dns` resolver using the same socket for the `A` and `AAAA` requests. 

Some hardware mistakenly sends back only one reply. When that happens the client system will sit and wait for the second reply. Turning this option on changes this behavior so that if two requests from the same port are not handled correctly it will close the socket and open a new one before sending the second request.

Enabling this option would update/set the following in `/etc/resolv.conf ` file:
`options single-request-reopen`

```
Before the updates:
---------------------
$ kubectl exec -it test-ows-performance-datacube-dev-6cc8897cc5-pfpbg -- cat /etc/resolv.conf 

nameserver 172.20.0.10
search default.svc.cluster.local svc.cluster.local cluster.local ap-southeast-2.compute.internal
options ndots:5

After the updates:
--------------------
$ kubectl exec -it test-ows-performance-datacube-dev-6cc8897cc5-pfpbg -- cat /etc/resolv.conf 

nameserver 172.20.0.10
search default.svc.cluster.local svc.cluster.local cluster.local ap-southeast-2.compute.internal
options ndots:5 single-request-reopen
