### PR TITLE
Add credentials in the docker env

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.5.6
+version: 0.5.7

--- a/stable/datacube-dashboard/templates/update_creation_dt.yaml
+++ b/stable/datacube-dashboard/templates/update_creation_dt.yaml
@@ -38,6 +38,16 @@ spec:
               value: {{ .Values.database.port | quote }}
             - name: DB_DATABASE
               value: {{ .Values.database.database | quote }}
+            - name: ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.adminSecret }}
+                  key: postgres-username
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.adminSecret }}
+                  key: postgres-password
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -48,6 +58,23 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.existingSecret }}
                   key: postgres-password
+            {{- if .Values.awsCredentialsSecret }}
+            - name: AWS_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.awsCredentialsSecret }}
+                  key: AWS_DEFAULT_REGION
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.awsCredentialsSecret }}
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.awsCredentialsSecret }}
+                  key: AWS_SECRET_ACCESS_KEY
+            {{- end }}
             {{- if .Values.additionalEnvironmentVars }}
             {{- range $arg, $value := .Values.updateCreationDt.additionalEnvironmentVars }}
             - name: {{ $arg | quote }}


### PR DESCRIPTION
Following are the updates within this PR:
- Add admin credentials to docker environment to allow automated script to create new database for cubedash processing
- Add AWS credentials to docker environment to allow automated script to push sns notification
