### PR TITLE
Service annotation

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.5.7
+version: 0.5.8

--- a/stable/datacube-dashboard/templates/service.yaml
+++ b/stable/datacube-dashboard/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ include "datacube-dashboard.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/datacube-dask/Chart.yaml
+++ b/stable/datacube-dask/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "alpha"
 description: Distributed Dask for Datacube
 name: datacube-dask
-version: 0.4.4
+version: 0.4.8

--- a/stable/datacube-dask/templates/service.yaml
+++ b/stable/datacube-dask/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/chart: {{ include "datacube-dask.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/datacube-dev-env/Chart.yaml
+++ b/stable/datacube-dev-env/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying a development environment to kubernetes
 name: datacube-dev-env
-version: 0.1.0
+version: 0.1.1

--- a/stable/datacube-dev-env/templates/service.yaml
+++ b/stable/datacube-dev-env/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ include "datacube-dev-env.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/datacube-wps/Chart.yaml
+++ b/stable/datacube-wps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: alpha
 description: A Helm chart for Datacube WPS on Kubernetes
 name: datacube-wps
-version: 0.7.3
+version: 0.7.4

--- a/stable/datacube-wps/templates/service.yaml
+++ b/stable/datacube-wps/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/chart: {{ include "datacube-wps.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/datacube/Chart.yaml
+++ b/stable/datacube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube
-version: 0.17.7
+version: 0.17.8
 keywords:
 - datacube
 - http

--- a/stable/datacube/templates/wms-service.yaml
+++ b/stable/datacube/templates/wms-service.yaml
@@ -8,6 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "datacube.fullname" . }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Add annotation support to all services that don't have it, 

This will be used to enable us to share a single ALB and have different health-checks per service.