### PR TITLE
Fix alb redirect issue

### DIFF
--- a/stable/datacube-dashboard/Chart.yaml
+++ b/stable/datacube-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Dashboard
 name: datacube-dashboard
-version: 0.5.8
+version: 0.5.9

--- a/stable/datacube-dashboard/templates/ingress.yaml
+++ b/stable/datacube-dashboard/templates/ingress.yaml
@@ -2,7 +2,6 @@
 {{- $fullName := include "datacube-dashboard.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressRedirect := .Values.ingress.redirect -}}
-{{- $redirectActionName := .Values.ingress.action -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -20,8 +19,9 @@ metadata:
 {{- end }}
 spec:
   rules:
-  {{- if $ingressRedirect -}}
-  {{- range .Values.ingress.hosts }}
+    {{- if $ingressRedirect -}}
+    {{- $redirectActionName := .Values.ingress.action -}}
+    {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}
       http:
         paths:
@@ -33,9 +33,9 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
-  {{- end }}
-  {{- else }}
-  {{- range .Values.ingress.hosts }}
+    {{- end }}
+    {{- else }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}
       http:
         paths:
@@ -43,11 +43,11 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
-  {{- end }}
-  {{- end }}
-  {{- if and .Values.global.domain .Values.ingress.prefixes }}
-  {{- $domain := .Values.global.domain }}
-  {{- range .Values.ingress.prefixes }}
+    {{- end }}
+    {{- end }}
+    {{- if and .Values.global.domain .Values.ingress.prefixes }}
+    {{- $domain := .Values.global.domain }}
+    {{- range .Values.ingress.prefixes }}
     - host: "{{ . }}.{{ $domain }}"
       http:
         paths:
@@ -55,6 +55,6 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
-  {{- end }}
-  {{- end }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/stable/datacube-dashboard/templates/ingress.yaml
+++ b/stable/datacube-dashboard/templates/ingress.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "datacube-dashboard.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressRedirect := .Values.ingress.redirect -}}
+{{- $redirectActionName := .Values.ingress.action -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -17,17 +19,22 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
   rules:
+  {{- if $ingressRedirect -}}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: {{ $redirectActionName }}
+              servicePort: use-annotation
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+  {{- else }}
   {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}
       http:
@@ -36,6 +43,7 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
+  {{- end }}
   {{- end }}
   {{- if and .Values.global.domain .Values.ingress.prefixes }}
   {{- $domain := .Values.global.domain }}


### PR DESCRIPTION
- Remove ingress tls as we are not using it
- Add rules to use `alb.ingress.kubernetes.io/actions.${action-name}` annotation ingress setup to redirect http traffic into https