### PR TITLE
Add a manifest for one-off index jobs

### DIFF
--- a/manifests/odc-s3-index/README.md
+++ b/manifests/odc-s3-index/README.md
@@ -1,0 +1,25 @@
+# ODC S3 Index Job
+
+
+This manifest will create a one-off job to index data from S3
+
+Create a local file called `kustomization.yaml` with these contents:
+
+```
+generatorOptions:
+  disableNameSuffixHash: true
+secretGenerator:
+- name: odc-s3-index-config
+  literals:
+    - DATACUBE_DB_URL=postgresql://username:password@host:5432/database
+    - PRODUCT_FILE=https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/products/fc/ls5_fc_albers.yaml
+    - BUCKET=dea-public-data
+    - PREFIX=fractional-cover/fc/v2.2.1/ls5/**/*.yaml
+    - AWS_ACCESS_KEY_ID=
+    - AWS_SECRET_ACCESS_KEY=
+    - AWS_DEFAULT_REGION=ap-southeast-2
+```
+
+Tweak the variables for your environment, then you can run it like `kubectl apply -k .`
+
+This will create a local secret that you can use to run jobs by running `kubectl apply -f <raw github url of odc-s3-index-job.yaml>`

--- a/manifests/odc-s3-index/odc-s3-index-job.yaml
+++ b/manifests/odc-s3-index/odc-s3-index-job.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: odc-s3-index-job
+spec:
+  template:
+    metadata:
+      name: odc-s3-index-job
+    spec:
+      dnsConfig:
+        options:
+          - name: single-request-reopen
+      containers:
+      - name: index
+        image: opendatacube/datacube-index:odc
+        args: 
+        - bin/bash -c
+        # configure datacube schema if it isn't done already
+        - datacube system init 
+        # list files in the s3 bucket, then index them
+        - echo 'Scanning s3 files, If it gets stuck here check your aws credentials are passed correctly'
+        - s3-find "s3://$BUCKET/$PREFIX" | s3-to-tar | dc-index-from-tar --ignore-lineage 
+        imagePullPolicy: IfNotPresent
+        env:
+        # should be a raw file url that of your datacube product
+        - name: PRODUCT_FILE
+          valueFrom:
+            secretKeyRef:
+              name: odc-s3-index-config
+              key: PRODUCT_FILE
+        # the bucket you're indexing from
+        - name: BUCKET
+          valueFrom:
+            secretKeyRef:
+              name: odc-s3-index-config
+              key: BUCKET
+        # a prefix filter to 
+        - name: PREFIX
+          valueFrom:
+            secretKeyRef:
+              name: odc-s3-index-config
+              key: PREFIX
+        # database connection string
+        - name: DATACUBE_DB_URL
+          valueFrom:
+            secretKeyRef:
+              name: odc-s3-index-config
+              key: DATACUBE_DB_URL
+        # AWS access keys
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: odc-s3-index-config
+              key: AWS_ACCESS_KEY_ID
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: odc-s3-index-config
+              key: AWS_SECRET_ACCESS_KEY
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              name: odc-s3-index-config
+              key: AWS_DEFAULT_REGION
+              optional: true
+      restartPolicy: OnFailure
+  backoffLimit: 2


### PR DESCRIPTION
Instead of leaving helm charts all over the place, this provides a simple way to run s3 index jobs, we can repeat this pattern for thredds and landsat / sentinel indexing scripts in the future. 


Still undergoing some dev