### PR TITLE
datacube-explorer - update deprecated kubernetes API version

### DIFF
--- a/stable/datacube-explorer/Chart.yaml
+++ b/stable/datacube-explorer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Explorer
 name: datacube-explorer
-version: 0.5.13
+version: 0.5.14
 keywords:
 - datacube
 - http

--- a/stable/datacube-explorer/templates/ingress.yaml
+++ b/stable/datacube-explorer/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressRedirect := .Values.ingress.redirect -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
datacube-explorer - update deprecated kubernetes API version as per guide here - https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/