### PR TITLE
upgrade ingress API verion to stable API - networking.k8s.io/v1

### DIFF
--- a/stable/datacube-explorer/Chart.yaml
+++ b/stable/datacube-explorer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Datacube Explorer
 name: datacube-explorer
-version: 0.5.14
+version: 0.5.15
 keywords:
 - datacube
 - http

--- a/stable/datacube-explorer/templates/ingress.yaml
+++ b/stable/datacube-explorer/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressRedirect := .Values.ingress.redirect -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/stable/datacube-ows/Chart.yaml
+++ b/stable/datacube-ows/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube-ows
-version: 0.18.5
+version: 0.18.6
 keywords:
 - datacube
 - http

--- a/stable/datacube-ows/templates/ows-ingress.yaml
+++ b/stable/datacube-ows/templates/ows-ingress.yaml
@@ -4,7 +4,7 @@
 # https://github.com/helm/helm/issues/3684#issuecomment-427932707
 {{- $dot := . }}
 {{- $servicePort := .Values.ows.externalPort }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "datacube-ows.fullname" . }}

--- a/stable/datacube-wps/Chart.yaml
+++ b/stable/datacube-wps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: alpha
 description: A Helm chart for Datacube WPS on Kubernetes
 name: datacube-wps
-version: 0.8.3
+version: 0.8.4

--- a/stable/datacube-wps/templates/ingress.yaml
+++ b/stable/datacube-wps/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "datacube-wps.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
We are good to use stable API version for ingress as per this doc: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html