### PR TITLE
Allow pyspy to access ows containers process

### DIFF
--- a/stable/datacube-ows/Chart.yaml
+++ b/stable/datacube-ows/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube-ows
-version: 0.18.8
+version: 0.18.9
 keywords:
 - datacube
 - http

--- a/stable/datacube-ows/templates/ows-deployment.yaml
+++ b/stable/datacube-ows/templates/ows-deployment.yaml
@@ -30,6 +30,10 @@ spec:
       annotations:
 {{ toYaml .Values.ows.annotations | indent 8 }}
     spec:
+{{- if .Values.pyspy.image }}
+      # When process namespace sharing is enabled, processes in a container are visible to all other containers in that pod.
+      shareProcessNamespace: true
+{{- end }}
       # Turning single-request-reopen option on would fix issue where in two requests from the same port are
       # not handled correctly it will close the socket and open a new one before sending the second request.
       dnsConfig:


### PR DESCRIPTION
https://v1-16.docs.kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/

needed to allow namespacesharing for pyspy sidecar to access the process in main ows container