### PR TITLE
Fix explorer ingress helm manifest

### DIFF
--- a/stable/datacube-explorer/Chart.yaml
+++ b/stable/datacube-explorer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Datacube Explorer
 name: datacube-explorer
-version: 0.5.24
+version: 0.5.25
 keywords:
 - datacube
 - http

--- a/stable/datacube-explorer/templates/ingress.yaml
+++ b/stable/datacube-explorer/templates/ingress.yaml
@@ -45,16 +45,4 @@ spec:
               servicePort: {{ $servicePort }}
     {{- end }}
     {{- end }}
-    {{- if and .Values.global.domain .Values.ingress.prefixes }}
-    {{- $domain := .Values.global.domain }}
-    {{- range .Values.ingress.prefixes }}
-    - host: "{{ . }}.{{ $domain }}"
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
-    {{- end }}
-    {{- end }}
 {{- end }}


### PR DESCRIPTION
fix ingress manifest as we have remove support for `.Values.global` attributes from `datacube-explorer` chart. This is currently breaking deployments