### PR TITLE
patch sa spec in deployment

### DIFF
--- a/stable/datacube-ows/templates/ows-deployment.yaml
+++ b/stable/datacube-ows/templates/ows-deployment.yaml
@@ -14,14 +14,6 @@ spec:
 {{- if not .Values.ows.autoscaling }}
   replicas: {{ .Values.minReplicas }}
 {{- end }}
-{{- if .Values.serviceAccount.enabled }}
-  serviceAccountName: {{ .Values.serviceAccount.name }}
-{{- end }}
-
-{{- with .Values.securityContext }}
-   securityContext:
-{{ toYaml . | indent 6 }}
-      {{- end }}
   selector:
     matchLabels:
       app: {{ template "datacube-ows.name" . }}
@@ -38,6 +30,13 @@ spec:
       annotations:
 {{ toYaml .Values.ows.annotations | indent 8 }}
     spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- end }}
 {{- if .Values.pyspy.image }}
       # When process namespace sharing is enabled, processes in a container are visible to all other containers in that pod.
       shareProcessNamespace: true


### PR DESCRIPTION
The add-service-account-support branch looks like it is WIP and is also broken so far as my testing was concerned.
I've patched the branch to place the service account spec where I believe it was intended to be in the WIP branch.

Would also like to see the WIP branch made into a PR but will wait until this patch PR is approved first.
