### PR TITLE
Unspecify WPS liveness probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ You can use these helm charts in your own kubernetes cluster by adding the helm 
 
 Documentation for installing each chart is available in their own directories
 
+## CI  Lint
+to pass lint and for each value change, please run `.github/helm-doc.sh` and this script will update the doc.

--- a/stable/datacube-wps/Chart.yaml
+++ b/stable/datacube-wps/Chart.yaml
@@ -2,4 +2,12 @@ apiVersion: v2
 appVersion: alpha
 description: A Helm chart for Datacube WPS on Kubernetes
 name: datacube-wps
-version: 0.8.9
+version: 0.8.10
+home: https://www.opendatacube.org/documentation
+# icon:
+sources:
+- https://github.com/opendatacube/datacube-core
+- https://github.com/opendatacube/datacube-wps
+maintainers:
+- name: Ben Lewis
+  email: ben.lewis@ga.gov.au

--- a/stable/datacube-wps/README.md
+++ b/stable/datacube-wps/README.md
@@ -34,11 +34,7 @@ Current chart version is `0.8.9`
 | wps.annotations | object | `{}` |  |
 | wps.baseurl | string | `""` |  |
 | wps.enabled | bool | `true` |  |
-| wps.livenessProbe.exec.command[0] | string | `"/bin/sh"` |  |
-| wps.livenessProbe.exec.command[1] | string | `"-c"` |  |
-| wps.livenessProbe.exec.command[2] | string | `"curl --silent 'http://localhost:8000/?service=WPS&request=GetCapabilities&version=1.0.0'"` |  |
-| wps.livenessProbe.initialDelaySeconds | int | `30` |  |
-| wps.livenessProbe.periodSeconds | int | `30` |  |
+| wps.livenessProbe | object | `{}` |  |
 | wps.readinessProbe | object | `{}` |  |
 | wps.resources.limits.cpu | string | `"2"` |  |
 | wps.resources.limits.memory | string | `"2048Mi"` |  |

--- a/stable/datacube-wps/README.md
+++ b/stable/datacube-wps/README.md
@@ -2,9 +2,9 @@ datacube-wps
 ============
 A Helm chart for Datacube WPS on Kubernetes
 
-Current chart version is `0.8.9`
+Current chart version is `0.8.10`
 
-
+Source code can be found [here](https://www.opendatacube.org/documentation)
 
 
 

--- a/stable/datacube-wps/values.yaml
+++ b/stable/datacube-wps/values.yaml
@@ -35,14 +35,7 @@ wps:
   annotations: { }
   additionalEnvironmentVars: { }
   securityContext: {}
-  livenessProbe:
-    exec:
-      command:
-      - "/bin/sh"
-      - "-c"
-      - "curl --silent 'http://localhost:8000/?service=WPS&request=GetCapabilities&version=1.0.0'"
-    initialDelaySeconds: 30
-    periodSeconds: 30
+  livenessProbe: {}
   readinessProbe: {}
 wpsConfig:
   image: { }


### PR DESCRIPTION
Specifying "exec" (for the shell to invoke `curl`) conflicts with being able to specify "httpGet" (native probe).

This relates to https://github.com/opendatacube/datacube-wps/issues/129

This probe formulation was already a bit broken because `curl` does not return nonzero exit code upon a server 500 response unless you include the `--fail` argument. It seems cleaner to admit the _native_ kubernetes syntax for a http probe.