### PR TITLE
Parameterise WPS ingress name

### DIFF
--- a/stable/datacube-wps/Chart.yaml
+++ b/stable/datacube-wps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: alpha
 description: A Helm chart for Datacube WPS on Kubernetes
 name: datacube-wps
-version: 0.8.10
+version: 0.8.11
 home: https://www.opendatacube.org/documentation
 # icon:
 sources:

--- a/stable/datacube-wps/README.md
+++ b/stable/datacube-wps/README.md
@@ -2,7 +2,7 @@ datacube-wps
 ============
 A Helm chart for Datacube WPS on Kubernetes
 
-Current chart version is `0.8.10`
+Current chart version is `0.8.11`
 
 Source code can be found [here](https://www.opendatacube.org/documentation)
 

--- a/stable/datacube-wps/templates/ingress.yaml
+++ b/stable/datacube-wps/templates/ingress.yaml
@@ -4,11 +4,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.name }}
-  name: {{ .Values.ingress.name }}
-  {{- else }}
-  name: {{ $fullName }}
-  {{- end }}
+  name: {{ or .Values.ingress.name $fullName }}
   labels:
     app.kubernetes.io/name: {{ include "datacube-wps.name" . }}
     helm.sh/chart: {{ include "datacube-wps.chart" . }}

--- a/stable/datacube-wps/templates/ingress.yaml
+++ b/stable/datacube-wps/templates/ingress.yaml
@@ -4,7 +4,11 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
+  {{- if .Values.ingress.name }}
+  name: {{ .Values.ingress.name }}
+  {{- else }}
   name: {{ $fullName }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "datacube-wps.name" . }}
     helm.sh/chart: {{ include "datacube-wps.chart" . }}


### PR DESCRIPTION
Some deployments may wish to host multiple services on different paths of _the same host domain_, which requires configuring the precedence order of routing rules (so that the more-specific rule has priority over the root-path rule). 

If using AWS Load Balancer then rule priority is determined by alphabetical sorting of the ingress names. (This is documented as _implicit_ ordering; the _explicit_ alternative is to manually assign a unique rank to each ingress individually, however reassigning rank integers requires a separate deallocation step that is incongruent with "infrastructure as code". The implicit approach seems far more maintainable for cases with several ingresses in the same routing group.) Hence, require an option to customise the ingress name, to facilitate configuring the precedence order.

Example use case: serving WPS from the /wps path on a subdomain shared by other OWS services. (The default ordering would otherwise give e.g. "ows-datacube" precedence ahead of "ows-wps". This change would enable renaming the WPS ingress to something like "ows-1-wps" to reverse the precedence.)