### PR TITLE
Update WPS hpa to v2beta2

### DIFF
--- a/stable/datacube-wps/Chart.yaml
+++ b/stable/datacube-wps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: alpha
 description: A Helm chart for Datacube WPS on Kubernetes
 name: datacube-wps
-version: 0.8.11
+version: 0.8.12
 home: https://www.opendatacube.org/documentation
 # icon:
 sources:

--- a/stable/datacube-wps/README.md
+++ b/stable/datacube-wps/README.md
@@ -2,7 +2,7 @@ datacube-wps
 ============
 A Helm chart for Datacube WPS on Kubernetes
 
-Current chart version is `0.8.11`
+Current chart version is `0.8.12`
 
 Source code can be found [here](https://www.opendatacube.org/documentation)
 

--- a/stable/datacube-wps/templates/hpa.yaml
+++ b/stable/datacube-wps/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "datacube-wps.fullname" . }}


### PR DESCRIPTION
autoscaler/v2beta1 was deprecated in kubernetes v1.19