### PR TITLE
OWS: Add pre-stop delay

### DIFF
--- a/stable/datacube-ows/Chart.yaml
+++ b/stable/datacube-ows/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube-ows
-version: 0.18.20
+version: 0.18.21
 keywords:
 - datacube
 - http

--- a/stable/datacube-ows/README.md
+++ b/stable/datacube-ows/README.md
@@ -2,7 +2,7 @@ datacube-ows
 ============
 Datacube Web Map Service
 
-Current chart version is `0.18.20`
+Current chart version is `0.18.21`
 
 Source code can be found [here](https://www.opendatacube.org/documentation)
 

--- a/stable/datacube-ows/templates/ows-deployment.yaml
+++ b/stable/datacube-ows/templates/ows-deployment.yaml
@@ -71,6 +71,10 @@ spec:
 {{- end }}
       containers:
       - name: ows
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/usr/bin/sleep", "15"]
         env:
 {{- if .Values.owsConfig.url }}
         - name: OWS_CONFIG_URL


### PR DESCRIPTION
Intended to ensure that requests can drain when pods terminating.

See https://github.com/opendatacube/datacube-ows/issues/764