### PR TITLE
update datacube ows helm chart

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.24.6
+          - v1.23.14
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,8 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.23.14
+          # https://hub.docker.com/r/kindest/node/tags
+          - v1.23.13
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,16 +40,16 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.16.1
+          - v1.24.6
     steps:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.4.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.3.1
         with:
           command: install
           config: .github/ct.yaml
@@ -65,12 +65,10 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.3
+          version: v3.10.0
 
       - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          version: v3.3.1
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Lint Charts
         run: |
@@ -88,7 +86,7 @@ jobs:
         run: ct lint --config ct-config.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.4.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/stable/datacube-ows/Chart.yaml
+++ b/stable/datacube-ows/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube-ows
-version: 0.18.21
+version: 0.19.0
 keywords:
 - datacube
 - http

--- a/stable/datacube-ows/README.md
+++ b/stable/datacube-ows/README.md
@@ -51,12 +51,12 @@ Source code can be found [here](https://www.opendatacube.org/documentation)
 | ows.resources.limits.memory | string | `"2048Mi"` |  |
 | ows.securityContext | object | `{}` | Deployment level security context |
 | ows.startupProbe | object | `{}` |  |
-| owsConfig.image.cfg_folder | string | `"/opt/dea-config/dev/services/wms/ows_refactored"` |  |
+| owsConfig.image.cfg_folder | string | `"/code/integration_tests/cfg"` |  |
 | owsConfig.image.pullPolicy | string | `"Always"` |  |
 | owsConfig.image.registry | string | `"docker.io"` |  |
-| owsConfig.image.repository | string | `"geoscienceaustralia/dea-datakube-config"` |  |
+| owsConfig.image.repository | string | `"opendatacube/ows"` |  |
 | owsConfig.image.tag | string | `"latest"` |  |
-| owsConfig.ows_cfg | string | `"ows_refactored.ows_root_cfg.ows_cfg"` |  |
+| owsConfig.ows_cfg | string | `"cfg.ows_test_cfg.ows_cfg"` |  |
 | owsConfig.path | string | `"/env/config"` |  |
 | owsConfig.securityContext | object | `{}` | Container level security context |
 | profiling.enabled | bool | `false` |  |

--- a/stable/datacube-ows/README.md
+++ b/stable/datacube-ows/README.md
@@ -2,7 +2,7 @@ datacube-ows
 ============
 Datacube Web Map Service
 
-Current chart version is `0.18.21`
+Current chart version is `0.19.0`
 
 Source code can be found [here](https://www.opendatacube.org/documentation)
 
@@ -33,7 +33,7 @@ Source code can be found [here](https://www.opendatacube.org/documentation)
 | ows.dockerArgs[6] | string | `"50"` |  |
 | ows.dockerArgs[7] | string | `"--timeout"` |  |
 | ows.dockerArgs[8] | string | `"120"` |  |
-| ows.dockerArgs[9] | string | `"datacube_wms.wsgi"` |  |
+| ows.dockerArgs[9] | string | `"datacube_ows.wsgi"` |  |
 | ows.enabled | bool | `true` |  |
 | ows.externalPort | int | `80` |  |
 | ows.hpa.autoscaling | bool | `true` |  |
@@ -51,12 +51,15 @@ Source code can be found [here](https://www.opendatacube.org/documentation)
 | ows.resources.limits.memory | string | `"2048Mi"` |  |
 | ows.securityContext | object | `{}` | Deployment level security context |
 | ows.startupProbe | object | `{}` |  |
+| owsConfig.image.cfg_folder | string | `"/opt/dea-config/dev/services/wms/ows_refactored"` |  |
 | owsConfig.image.pullPolicy | string | `"Always"` |  |
 | owsConfig.image.registry | string | `"docker.io"` |  |
 | owsConfig.image.repository | string | `"geoscienceaustralia/dea-datakube-config"` |  |
 | owsConfig.image.tag | string | `"latest"` |  |
+| owsConfig.ows_cfg | string | `"ows_refactored.ows_root_cfg.ows_cfg"` |  |
+| owsConfig.path | string | `"/env/config"` |  |
 | owsConfig.securityContext | object | `{}` | Container level security context |
-| profiling.enabled | bool | `true` |  |
+| profiling.enabled | bool | `false` |  |
 | profiling.path | string | `"/opt/profiling/"` |  |
 | prometheus.enabled | bool | `false` |  |
 | prometheus.path | string | `"/opt/prometheus/"` |  |

--- a/stable/datacube-ows/templates/ows-deployment.yaml
+++ b/stable/datacube-ows/templates/ows-deployment.yaml
@@ -76,14 +76,6 @@ spec:
             exec:
               command: ["/usr/bin/sleep", "15"]
         env:
-{{- if .Values.owsConfig.url }}
-        - name: OWS_CONFIG_URL
-          value: {{ .Values.owsConfig.url | quote }}
-{{- end }}
-{{- if or .Values.owsConfig.configMap .Values.owsConfig.image }}
-        - value: "{{ .Values.owsConfig.path }}/{{ .Values.owsConfig.filename }}"
-          name: OWS_CONFIG_PATH
-{{- end }}
         - name: DB_HOSTNAME
           value: {{ .Values.database.host | quote }}
         - name: DB_PORT
@@ -100,6 +92,10 @@ spec:
             secretKeyRef:
               name: {{ template "datacube-ows.secretName" . }}
               key: postgres-password
+        - name: DATACUBE_OWS_CFG
+          value: {{ .Values.owsConfig.ows_cfg }}
+        - name: PYTHONPATH
+          value: {{ .Values.owsConfig.path}}
         - name: VIRTUAL_HOST
           value: localhost,127.0.0.
 {{- if $prometheus.enabled }}

--- a/stable/datacube-ows/values.yaml
+++ b/stable/datacube-ows/values.yaml
@@ -56,14 +56,17 @@ ows:
 owsConfig:
   image:
     registry: docker.io
-    repository: geoscienceaustralia/dea-datakube-config
+    repository: opendatacube/ows
     tag: latest
     pullPolicy: Always
-    cfg_folder: "/opt/dea-config/dev/services/wms/ows_refactored"
+    # the folder location within the docker image that contains
+    # ows config file
+    cfg_folder: "/code/integration_tests/cfg"
   # owsConfig.securityContext -- Container level security context
   securityContext: {}
   path: "/env/config"
-  ows_cfg: "ows_refactored.ows_root_cfg.ows_cfg"
+  # the ows config python objection
+  ows_cfg: "cfg.ows_test_cfg.ows_cfg"
 
 pyspy:
   image: {}

--- a/stable/datacube-ows/values.yaml
+++ b/stable/datacube-ows/values.yaml
@@ -42,7 +42,7 @@ ows:
     limits:
       cpu: "1"
       memory: 2048Mi
-  dockerArgs: [ "gunicorn", "-b", "0.0.0.0:8000", "-w", "4", "--keep-alive", "50", "--timeout", "120", "datacube_wms.wsgi" ]
+  dockerArgs: [ "gunicorn", "-b", "0.0.0.0:8000", "-w", "4", "--keep-alive", "50", "--timeout", "120", "datacube_ows.wsgi" ]
   annotations:
     iam.amazonaws.com/role: kubernetes-wms
   livenessProbe: {}
@@ -59,8 +59,11 @@ owsConfig:
     repository: geoscienceaustralia/dea-datakube-config
     tag: latest
     pullPolicy: Always
+    cfg_folder: "/opt/dea-config/dev/services/wms/ows_refactored"
   # owsConfig.securityContext -- Container level security context
   securityContext: {}
+  path: "/env/config"
+  ows_cfg: "ows_refactored.ows_root_cfg.ows_cfg"
 
 pyspy:
   image: {}
@@ -79,7 +82,7 @@ prometheus:
 ## cProfiling, only enable for debugging and profiling purposes
 ##
 profiling:
-  enabled: true
+  enabled: false
   path: "/opt/profiling/"
 
 service:


### PR DESCRIPTION
adding ows helm chart to ows documentation (https://github.com/opendatacube/datacube-ows/pull/898), while testing, the current helm fails to start. Updating helm chart to successfully start

This was tested by running 
```
helm install datacube-ows-local ./datacube-ows/ --values datacube-ows/values.yaml
```

### Changes
- set profiling default to false
- add `ows_cfg` to `owsConfig` with default value integration test config file used in `datacube/ows`
- set default `owsConfig` image to `opendatacube/ows`
- add `path` to values.yaml
- remove unsupported environment variables `OWS_CONFIG_URL` and `OWS_CONFIG_PATH` as per this [pr](https://github.com/opendatacube/datacube-ows/pull/901)
- update `dockerArg` to use `datacube_ows.wsgi` instead of legacy `datacube_wms.wsgi`

## Updates
- update github ci