### PR TITLE
Update WPS ingress to stable API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ You can use these helm charts in your own kubernetes cluster by adding the helm 
 Documentation for installing each chart is available in their own directories
 
 ## CI  Lint
-to pass lint and for each value change, please run `.github/helm-doc.sh` and this script will update the doc.
+to pass lint and for each value change, please run `.github/helm-docs.sh` and this script will update the doc.

--- a/stable/datacube-wps/Chart.yaml
+++ b/stable/datacube-wps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: alpha
 description: A Helm chart for Datacube WPS on Kubernetes
 name: datacube-wps
-version: 0.8.12
+version: 0.9.0
 home: https://www.opendatacube.org/documentation
 # icon:
 sources:

--- a/stable/datacube-wps/README.md
+++ b/stable/datacube-wps/README.md
@@ -1,6 +1,6 @@
 # datacube-wps
 
-![Version: 0.8.12](https://img.shields.io/badge/Version-0.8.12-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
 A Helm chart for Datacube WPS on Kubernetes
 

--- a/stable/datacube-wps/templates/ingress.yaml
+++ b/stable/datacube-wps/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "datacube-wps.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ or .Values.ingress.name $fullName }}
@@ -31,9 +31,12 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port: 
+                  name: http
   {{- end }}
   {{- $domain := .Values.ingress.domain }}
   {{- range .Values.ingress.prefixes }}
@@ -41,8 +44,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Required update for compatibility with current versions of Kubernetes.

(This is intended as a minimal change, to facilitate a re-deployment for testing and reassessment.)

See:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/
https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/