### PR TITLE
Update autoscaling API versions for HPA

### DIFF
--- a/stable/datacube-dask/templates/worker-hpa.yaml
+++ b/stable/datacube-dask/templates/worker-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.adaptive.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "datacube-dask.fullname" . }}-worker

--- a/stable/datacube-ows/templates/autoscaling.yaml
+++ b/stable/datacube-ows/templates/autoscaling.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ows.enabled }}
 {{- if .Values.ows.hpa.autoscaling }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "datacube-ows.fullname" . }}

--- a/stable/datacube-wps/templates/hpa.yaml
+++ b/stable/datacube-wps/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "datacube-wps.fullname" . }}


### PR DESCRIPTION
The v2betaX API versions were deprecated in Kubernetes 1.23 and are being removed in 1.26.

References:
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26
- https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/