### PR TITLE
Update ows chart to handle ingressClassName

### DIFF
--- a/stable/datacube-ows/Chart.yaml
+++ b/stable/datacube-ows/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datacube Web Map Service
 name: datacube-ows
-version: 0.20.0
+version: 0.20.1
 keywords:
 - datacube
 - http

--- a/stable/datacube-ows/README.md
+++ b/stable/datacube-ows/README.md
@@ -16,6 +16,7 @@ Source code can be found [here](https://www.opendatacube.org/documentation)
 | database.existingSecret | string | `nil` |  |
 | database.host | string | `"localhost"` |  |
 | database.port | int | `5432` |  |
+| ingress.ingressClassName | string | `""` |  | 
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0] | string | `""` |  |

--- a/stable/datacube-ows/templates/ows-ingress.yaml
+++ b/stable/datacube-ows/templates/ows-ingress.yaml
@@ -25,6 +25,9 @@ metadata:
 {{- end }}
 
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}


### PR DESCRIPTION
The recommended way to associate an ingress to an ingressclass is use the ingressClassName attribute in the spec, and no longer as an annotation