### PR TITLE
CI: drop permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
 env:
   CHARTS_DEST: https://opendatacube.github.io/datacube-charts/charts
 
+permissions: {}
+
 jobs:
   publish:
     permissions:


### PR DESCRIPTION
The jobs inherit the permissions
configured for the repository
without this, and those permissions
are more than just read rights
in the opendatacube organization.